### PR TITLE
Ajeita fetch_tramitacao_camara

### DIFF
--- a/R/tramitacoes.R
+++ b/R/tramitacoes.R
@@ -135,7 +135,7 @@ fetch_tramitacao_camara <- function(bill_id, normalized=FALSE) {
     tram_camara <- tram_camara %>%
       dplyr::mutate(data_hora = lubridate::ymd_hm(stringr::str_replace(data_hora,'T',' ')),
                     casa = 'camara',
-                    id_situacao = as.integer(id_tipo_tramitacao)) %>%
+                    id_situacao = as.integer(cod_tipo_tramitacao)) %>%
       dplyr::select(prop_id = id_prop,
                     casa,
                     data_hora,


### PR DESCRIPTION
A API da câmara mudou `id` pro `cod`, então:

- Troca nome da coluna de `id_tipo_tramitacao` para `cod_tipo_tramitacao`